### PR TITLE
Add "--weights" command line argument which allows for weight values to be specified for multiple "--datacenter" targets in one command

### DIFF
--- a/command.go
+++ b/command.go
@@ -141,6 +141,10 @@ var commandLocator akamai.CommandLocator = func() ([]cli.Command, error) {
 				Usage: "Apply 'weight' to specified datacenter.",
 			},
 			cli.StringSliceFlag{
+				Name:  "weights",
+				Usage: "Apply these 'weight' values to the specified datacenters.",
+			},
+			cli.StringSliceFlag{
 				Name:  "server",
 				Usage: "Update target server for specified datacenter. Multiple server flags may be specified.",
 			},


### PR DESCRIPTION
Currently the GTM CLI only allows for one weight to be specified for only one Data Center in one command execution.

This limitation renders the GTM CLI unusable for failover GTM configurations which use a weight value of "1" to indicate the primary target and "0" for backup targets.  By adding the `--weights` configuration parameter which can be specified more than once the GTM CLI is enhanced to allow the changing of the weight value for more than one target in one command execution.

For example, given a failover GTM property with two enabled data centers the following GTM CLI command will set data center 100 as backup (weight = 0) and data center 101 as primary (weight = 1):

    akamai-gtm update-property example.akadns.net www --datacenter 100 --weights 0 --datacenter 101 --weights 1 --complete

Then the following command can be used to reverse the state back to data center 100 as primary (weight = 1) and data center 101 as backup (weight = 0):

    akamai-gtm update-property example.akadns.net www --datacenter 100 --weights 1 --datacenter 101 --weights 0 --complete

Error checking prevents the use of both `--weight` and `--weights` in the same command.  The values specified for `--weights` are checked to ensure that they are `Float64` which is the `go` type of the `weight` property.   Finally the number of `--dataccenter` and `--weights` parameters must be equal or an error is flagged.